### PR TITLE
Allow views folder to be relative to base_path()

### DIFF
--- a/src/Themes.php
+++ b/src/Themes.php
@@ -81,7 +81,7 @@ class Themes{
 				$path = base_path(substr($theme->viewsPath, 1));
 			} else {
 				$path = $this->themesPath;
-				$path .= empty($theme->viewsPath) ? '' : '/' . $theme->viewsPath;
+				$path .= empty($theme->viewsPath) ? '' : DIRECTORY_SEPARATOR . $theme->viewsPath;
 			}
 			if(!in_array($path, $paths))
 				$paths[] = $path;

--- a/src/Themes.php
+++ b/src/Themes.php
@@ -77,9 +77,12 @@ class Themes{
 		// All paths are relative to Config::get('theme.theme_path')
 		$paths = [];
 		do {
-			// $path = $this->defaultViewsPath[0];
-            $path = $this->themesPath;
-			$path .= empty($theme->viewsPath) ? '' : '/'.$theme->viewsPath;
+			if(substr($theme->viewsPath, 0, 1) === DIRECTORY_SEPARATOR){
+				$path = base_path(substr($theme->viewsPath, 1));
+			} else {
+				$path = $this->themesPath;
+				$path .= empty($theme->viewsPath) ? '' : '/' . $theme->viewsPath;
+			}
 			if(!in_array($path, $paths))
 				$paths[] = $path;
 		} while ($theme = $theme->getParent());


### PR DESCRIPTION
Small buff - 
if the themes viewsPath starts with a DIRECTORY_SERPARATOR (aka /) then the views path becomes relative to the applications configured base path.

Similar to issue #23 except this allows you to override the package wide theme_path for the single theme if so required (useful if say you have themes that are pulled in from composer).